### PR TITLE
Updating for GitHub Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ This GitHub Action will create a backup file for the specified database and publ
 
 ## Index
 
-- [Inputs](#inputs)
-- [Example](#example)
-- [Contributing](#contributing)
-  - [Incrementing the Version](#incrementing-the-version)
-- [Code of Conduct](#code-of-conduct)
-- [License](#license)
+- [create-and-publish-db-backup-file](#create-and-publish-db-backup-file)
+  - [Index](#index)
+  - [Inputs](#inputs)
+  - [Example](#example)
+  - [Contributing](#contributing)
+    - [Incrementing the Version](#incrementing-the-version)
+  - [Code of Conduct](#code-of-conduct)
+  - [License](#license)
 
 ## Inputs
 
@@ -23,6 +25,7 @@ This GitHub Action will create a backup file for the specified database and publ
 | `nuget-source-url` | true        | The url to the nuget repository where the backup file will be pushed.                                             |
 | `nuget-api-key`    | true        | The PAT for the nuget repository where the backup file will be published.                                         |
 | `authors`          | false       | A string containing the names of the authors of the backup file. There is no required formatting for this string. |
+| `repository-url`   | false       | Use when publishing to GitHub Packages. The url to the repository which should house the published packages.      |
 
 ## Example
 
@@ -56,6 +59,7 @@ jobs:
           nuget-source-url: "https://github.com/my-org/my-repo" # A GitHub packages url
           nuget-api-key: "${{ secrets.MY_GH_PACKAGES_ACCESS_TOKEN }}" # A token that has access to publish packages
           authors: "My-Team"
+          repository-url: "git://github.com/my-org/my-repo.git" # The URL to the repository.
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ jobs:
           drop-db-after-build: false
 
       - name: Create and Publish Backup File
-        uses: im-open/create-and-publish-db-backup-file@v1.0.3
+        uses: im-open/create-and-publish-db-backup-file@v1.1.0
         with:
           db-server: localhost
           db-name: LocalDb

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,9 @@ inputs:
   authors:
     description: A string containing the names of the authors of the backup file. There is no required formatting for this string.
     required: false
+  repository-url:
+    description: Use when publishing to GitHub Packages. The url to the repository which should house the published packages.
+    required: false
 
 runs:
   using: "composite"
@@ -41,4 +44,5 @@ runs:
         -Version "${{ inputs.version }}" `
         -NugetSourceUrl "${{ inputs.nuget-source-url }}" `
         -NugetApiKey "${{ inputs.nuget-api-key }}" `
-        -Authors "${{ inputs.authors }}"
+        -Authors "${{ inputs.authors }}" `
+        -RepositoryUrl "${{ inputs.repository-url }}"

--- a/src/createPublishBackupFiles.ps1
+++ b/src/createPublishBackupFiles.ps1
@@ -6,7 +6,8 @@ param (
     [string]$Version,
     [string]$NugetSourceUrl,
     [string]$NugetApiKey,
-    [string]$Authors
+    [string]$Authors,
+    [string]$RepositoryUrl
 )
 
 $fullPath = (Get-Item -Path $BackupPath).FullName # Use absolute path
@@ -23,6 +24,7 @@ $packageManifest = @"
     <version>$Version</version>
     <description>Encapsulates a single backup file called $BackupName</description>
     <authors>$Authors</authors>
+    <repository url="$RepositoryUrl"></repository>
 </metadata>
 <files>
     <file src="$backupPathAndName"/>
@@ -33,7 +35,7 @@ $packageManifest = @"
 $targetNugetExe = "$PSScriptRoot\.nuget\nuget.exe"
 $sourceNugetExe = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 
-if(![System.IO.File]::Exists($targetNugetExe)) {
+if (![System.IO.File]::Exists($targetNugetExe)) {
     Write-Host "Downloading nuget.exe"
     New-Item -ItemType Directory -Path "$PSScriptRoot\.nuget"
     Invoke-WebRequest $sourceNugetExe -OutFile $targetNugetExe


### PR DESCRIPTION
# Summary of PR changes

Added a new parameter that will allow the generated nuget package to be associated with a repository.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
